### PR TITLE
Standardize API and Frontend Interface

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -33,11 +33,11 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json({ extended: true }));
 app.use(express.static(path.join(new URL('.', import.meta.url).pathname, 'static')));
 
-app.get('/api/label/images', async (req, res) => {
+app.get('/api/labels/images', async (req, res) => {
   res.json(await getPresetImages());
 });
 
-app.delete('/api/label/image', async (req, res) => {
+app.delete('/api/labels/images', async (req, res) => {
   if (!req.body || !req.body.filename) {
     res.status(400);
     res.json({
@@ -51,16 +51,20 @@ app.delete('/api/label/image', async (req, res) => {
   res.json({});
 });
 
-app.post('/api/label/images', async (req, res) => {
-  const redirect = req.headers.referer || '/';
+app.post('/api/labels/images', async (req, res) => {
   if (!req.files || !req.files['upload-image']) {
-    res.redirect(redirect);
+    res.status(400);
+    res.json({
+      error: {
+        msg: 'No image uploaded.',
+      }
+    });
     return;
   }
 
   const imgFile = req.files['upload-image'];
   await uploadImage(imgFile);
-  res.redirect(redirect);
+  res.json({});
 });
 
 app.get('/api/labels/titles', async (req, res) => {
@@ -82,15 +86,19 @@ app.delete('/api/labels/titles', async (req, res) => {
 });
 
 app.post('/api/labels/titles', async (req, res) => {
-  const redirect = req.headers.referer || '/';
   if (!req.body || !req.body.title) {
-    res.redirect(redirect);
+    res.status(400);
+    res.json({
+      error: {
+        msg: 'Title must be provided.',
+      }
+    });
     return;
   }
 
   const title = req.body.title;
   await addTitle(title);
-  res.redirect(redirect);
+  res.json({});
 });
 
 app.get('/api/labels/addresses', async (req, res) => {
@@ -112,15 +120,19 @@ app.delete('/api/labels/addresses', async (req, res) => {
 });
 
 app.post('/api/labels/addresses', async (req, res) => {
-  const redirect = req.headers.referer || '/';
   if (!req.body || !req.body.address) {
-    res.redirect(redirect);
+    res.status(400);
+    res.json({
+      error: {
+        msg: 'Address must be provided.',
+      }
+    });
     return;
   }
 
   const address = req.body.address;
   await addAddress(address);
-  res.redirect(redirect);
+  res.json({});
 });
 
 app.post('/api/print', async (req, res) => {
@@ -184,11 +196,11 @@ app.get('/api/labels', async (req, res) => {
 });
 
 
-app.get('/api/label/:filename', async (req, res) => {
+app.get('/api/labels/:filename', async (req, res) => {
   res.json(await getSavedLabel(req.params.filename));
 });
 
-app.post('/api/label', async (req, res) => {
+app.post('/api/labels', async (req, res) => {
   if (!req.body) {
     res.status(400);
     res.json({
@@ -201,13 +213,9 @@ app.post('/api/label', async (req, res) => {
 
   try {
     const filename = await addLabel(req.body);
-    if (req.body.redirect) {
-      const url = new URL(req.body.redirect, req.headers.referer || '/');
-      url.searchParams.set('label', filename);
-      res.redirect(url.href);
-    } else {
-      res.json({});
-    }
+    res.json({
+      filename,
+    });
   } catch (err) {
     res.status(400);
     res.json({
@@ -218,7 +226,7 @@ app.post('/api/label', async (req, res) => {
   }
 });
 
-app.delete('/api/label', async (req, res) => {
+app.delete('/api/labels', async (req, res) => {
   if (!req.body || !req.body.filename) {
     res.status(400);
     res.json({

--- a/content/add-image.html
+++ b/content/add-image.html
@@ -4,10 +4,8 @@ title: "Add New Image"
 
 <h1>Add New Image</h1>
 
-<form class="l-form" method="post" action="{{< api_domain >}}/api/label/images" encType="multipart/form-data">
-  <label class="c-img-drop js-img-drop" for="img-file-input"><input id="img-file-input" type="file" accept=".svg" name="upload-image" /></label>
+<form class="l-form js-add-image-form" method="post" action="{{< api_domain >}}/api/labels/images" encType="multipart/form-data">
+  <label class="c-img-drop js-img-drop" for="img-file-input"><input id="img-file-input" type="file" accept=".svg" name="upload-image" required /></label>
   <div class="js-img-drop-preview"></div>
   <button class="c-btn">Save Image(s)</button>
-
-  <input type="hidden" name="redirect" value="/create-label">
 </form>

--- a/content/create-label.html
+++ b/content/create-label.html
@@ -7,9 +7,7 @@ title: "Create New Label"
 <label>Preview</label>
 <div class="l-labels-list js-create-label"></div>
 
-<form class="l-form js-create-label__form" method="post" action="{{< api_domain >}}/api/label" encType="multipart/form-data">
-  <input type="hidden" name="redirect" value="/print-label">
-
+<form class="l-form js-create-label__form" method="post" action="{{< api_domain >}}/api/labels">
   <h2>Select an Image</h2>
   <div class="c-imgs-list js-imgs-list"></div>
   <a class="c-btn" href="/add-image">Add new image</a>

--- a/content/settings/index.html
+++ b/content/settings/index.html
@@ -42,13 +42,12 @@ title: "Settings"
 
     <h3>Add New Image</h3>
 
-    <form method="post" action="{{< api_domain >}}/api/labels/images" encType="multipart/form-data">
+    <form method="post" action="{{< api_domain >}}/api/labels/images" encType="multipart/form-data" class="js-api-form">
         <div class="l-input-btn">
             <label class="c-wrap-file-input drac-btn drac-bg-purple-transparent drac-btn-ghost drac-text-purple">
-                <input type="file" accept=".svg" name="upload-image">
+                <input type="file" accept=".svg" name="upload-image" required>
                 Select SVG File
             </label>
-            <input type="hidden" name="form-url" value="/settings/">
             <button class="drac-btn drac-bg-purple-cyan drac-text-black" type="submit">Upload</button>
         </div>
     </form>
@@ -71,14 +70,14 @@ title: "Settings"
 
     <h3>Add New Title</h3>
 
-    <form method="post" action="{{< api_domain >}}/api/labels/titles" encType="multipart/form-data">
+    <form method="post" action="{{< api_domain >}}/api/labels/titles" encType="multipart/form-data" class="js-api-form">
         <div class="l-input-btn">
             <input
                 name="title"
                 placeholder="New title...."
                 class="drac-input drac-input-purple drac-text-purple"
+                required
             />
-            <input type="hidden" name="form-url" value="/settings/">
             <button class="drac-btn drac-bg-purple-cyan drac-text-black" type="submit">Add</button>
         </div>
     </form>
@@ -101,15 +100,15 @@ title: "Settings"
 
     <h3>Add New Address</h3>
 
-    <form method="post" action="{{< api_domain >}}/api/labels/addresses" encType="multipart/form-data">
+    <form method="post" action="{{< api_domain >}}/api/labels/addresses" encType="multipart/form-data" class="js-api-form">
         <div class="l-input-btn">
             <textarea
                 name="address"
                 placeholder="New address...."
                 rows="6"
                 class="c-textarea drac-py-xs drac-input drac-input-purple drac-text-purple"
+                required
             ></textarea>
-            <input type="hidden" name="form-url" value="/settings/">
             <button class="drac-btn drac-bg-purple-cyan drac-text-black" type="submit">Add</button>
         </div>
     </form>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2713,6 +2713,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/ftp": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
@@ -7714,6 +7728,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "optional": true
     },
     "ftp": {
       "version": "0.3.10",

--- a/themes/printboy/assets/ts/api/_images.ts
+++ b/themes/printboy/assets/ts/api/_images.ts
@@ -1,7 +1,7 @@
 import {fetch} from './_fetch';
 
 export async function getImages(): Promise<ImageData> {
-  const data = await fetch('/api/label/images', {
+  const data = await fetch('/api/labels/images', {
     method: 'GET',
   });
   return data;

--- a/themes/printboy/assets/ts/ui/js-api-forms.ts
+++ b/themes/printboy/assets/ts/ui/js-api-forms.ts
@@ -1,0 +1,41 @@
+import {OnLoad} from '../utils/_onload';
+import {fetch} from '../api/_fetch';
+
+async function setupApiForms() {
+  const forms = document.querySelectorAll<HTMLFormElement>('.js-api-form');
+  for (const form of forms) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+
+      const formData = new FormData(form);
+      const url = form.action;
+      const method = form.method || 'POST';
+
+      const options: RequestInit = {
+        method,
+      };
+
+      if (form.enctype === 'multipart/form-data') {
+        options.body = formData;
+      } else {
+        const data = Object.fromEntries(formData.entries());
+        options.body = JSON.stringify(data);
+        options.headers = {
+          'Content-Type': 'application/json',
+        };
+      }
+
+      try {
+        const resp = await fetch(url, options);
+        // On success, reload the page to show new data
+        // This is a simple way to handle the update for now
+        window.location.reload();
+      } catch (err) {
+        console.error('Form submission failed:', err);
+        alert(`Failed to save: ${err.message}`);
+      }
+    });
+  }
+}
+
+OnLoad(setupApiForms);

--- a/themes/printboy/assets/ts/ui/js-create-label.ts
+++ b/themes/printboy/assets/ts/ui/js-create-label.ts
@@ -61,6 +61,26 @@ async function labelForm() {
         label.setContent(contentInput.value);
       });
     }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(form as HTMLFormElement);
+      const data = Object.fromEntries(formData.entries());
+      try {
+        const {fetch} = await import('../api/_fetch');
+        const resp = await fetch((form as HTMLFormElement).action, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(data),
+        });
+        window.location.href = `/print-label?label=${resp.filename}`;
+      } catch (err) {
+        console.error('Failed to save label:', err);
+        alert(`Failed to save label: ${err.message}`);
+      }
+    });
   }
 }
 

--- a/themes/printboy/assets/ts/ui/js-delete-label.ts
+++ b/themes/printboy/assets/ts/ui/js-delete-label.ts
@@ -20,7 +20,7 @@ async function deleteLabel() {
     e.preventDefault();
     element.disabled = true;
     try {
-      await fetch('/api/label', {
+      await fetch('/api/labels', {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',

--- a/themes/printboy/assets/ts/ui/js-img-drop.ts
+++ b/themes/printboy/assets/ts/ui/js-img-drop.ts
@@ -94,7 +94,7 @@ function initInput(input) {
 }
 
 async function imgDrop() {
-  const element = document.querySelector('.js-img-drop');
+  const element = document.querySelector<HTMLElement>('.js-img-drop');
   if (!element) {
     logger.error('Failed to find js-img-drop element');
     return;
@@ -106,6 +106,25 @@ async function imgDrop() {
   }
   initDragAndDrop(element, input);
   initInput(input);
+
+  const form = document.querySelector<HTMLFormElement>('.js-add-image-form');
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(form);
+      try {
+        const {fetch} = await import('../api/_fetch');
+        await fetch(form.action, {
+          method: 'POST',
+          body: formData,
+        });
+        window.location.href = '/create-label';
+      } catch (err) {
+        console.error('Failed to upload image:', err);
+        alert(`Failed to upload image: ${err.message}`);
+      }
+    });
+  }
 }
 
 OnLoad(imgDrop);

--- a/themes/printboy/assets/ts/ui/js-paper-select-input.ts
+++ b/themes/printboy/assets/ts/ui/js-paper-select-input.ts
@@ -2,8 +2,8 @@ import {OnLoad} from '../utils/_onload';
 import { apiDomain } from '../config';
 import {logger} from '@gauntface/logger';
 
-async function imgDrop() {
-  const element = document.querySelector('.js-paper-select-input');
+async function paperSelect() {
+  const element = document.querySelector<HTMLSelectElement>('.js-paper-select-input');
   if (!element) {
     logger.error('Failed to find js-paper-select-input element');
     return;
@@ -26,4 +26,4 @@ async function imgDrop() {
   }
 }
 
-OnLoad(imgDrop);
+OnLoad(paperSelect);

--- a/themes/printboy/assets/ts/ui/js-print-label.ts
+++ b/themes/printboy/assets/ts/ui/js-print-label.ts
@@ -25,7 +25,7 @@ async function printLabel() {
     throw new Error(`Failed to get "label" from the search parameters`);
   }
 
-  const labelData = await fetch(`/api/label/${filename}`, {
+  const labelData = await fetch(`/api/labels/${filename}`, {
     method: 'GET',
   });
 


### PR DESCRIPTION
Standardized the API interface between backend and frontend.

Key changes:
1. Pluralized all `/api/label` endpoints to `/api/labels`.
2. Standardized all POST responses to return JSON, removing browser redirects.
3. Updated the frontend to use AJAX (fetch) for form submissions, handling JSON responses and client-side navigation/reloading.
4. Consistent use of plural resource names across both the API and frontend code.
5. Ensured DELETE requests continue to use request bodies for resource identification as requested.

---
*PR created automatically by Jules for task [14283310830025924346](https://jules.google.com/task/14283310830025924346) started by @gauntface*